### PR TITLE
Use libresource's 'player' type for AUDIO_RESOURCE_MEDIA requests

### DIFF
--- a/src/audioresource.c
+++ b/src/audioresource.c
@@ -69,10 +69,7 @@ audioresource_t *audioresource_init(enum audioresource_type_t type,
             type_str = "game";
             break;
         case AUDIO_RESOURCE_MEDIA:
-            //type_str = "media";
-            // XXX: Workaround for now, as the backend doesn't
-            // know about "media" yet
-            type_str = "game";
+            type_str = "player";
             break;
         default:
             /* Invalid audio resource type */


### PR DESCRIPTION
The 'player' type fits the role of media handling more neatly than the 'game' type.
